### PR TITLE
feat: Phase 1 - 基本設定（フォント、カラースキーム、ウィンドウ）

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -1,0 +1,36 @@
+-- WezTerm設定ファイル
+-- Phase 1: 基本設定（フォント、カラー、ウィンドウ）
+
+local wezterm = require("wezterm")
+local config = wezterm.config_builder()
+
+----------------------------------------------------
+-- フォント設定
+----------------------------------------------------
+config.font = wezterm.font("JetBrains Mono", { weight = "Medium" })
+config.font_size = 14.0
+
+----------------------------------------------------
+-- カラースキーム
+----------------------------------------------------
+config.color_scheme = "Tokyo Night"
+
+----------------------------------------------------
+-- ウィンドウ設定
+----------------------------------------------------
+-- ウィンドウの背景透過
+config.window_background_opacity = 0.95
+config.macos_window_background_blur = 20
+
+-- ウィンドウの装飾
+config.window_decorations = "RESIZE"
+
+-- ウィンドウのパディング
+config.window_padding = {
+  left = 10,
+  right = 10,
+  top = 10,
+  bottom = 10,
+}
+
+return config


### PR DESCRIPTION
## 📦 Phase 1: 基本設定

WezTermのミニマム設定を追加しました。

### 追加された機能
- ✅ **フォント**: JetBrains Mono (Medium, 14pt)
- ✅ **カラースキーム**: Tokyo Night
- ✅ **背景透過**: 95%不透明度 + macOSぼかし効果
- ✅ **ウィンドウ装飾**: RESIZEスタイル
- ✅ **パディング**: 10pxの余白設定

### 動作確認
- [x] 設定ファイルの構文チェック完了
- [x] フォント読み込み確認
- [x] 実機での動作確認完了

### 次のステップ
Phase 2でタブバーのカスタマイズを予定