### PR TITLE
feat: Phase 2 - タブバーのカスタマイズ

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -1,5 +1,6 @@
 -- WezTerm設定ファイル
 -- Phase 1: 基本設定（フォント、カラー、ウィンドウ）
+-- Phase 2: タブバーのカスタマイズ
 
 local wezterm = require("wezterm")
 local config = wezterm.config_builder()
@@ -32,5 +33,73 @@ config.window_padding = {
   top = 10,
   bottom = 10,
 }
+
+----------------------------------------------------
+-- タブバー設定
+----------------------------------------------------
+-- タブバーを有効化
+config.enable_tab_bar = true
+config.use_fancy_tab_bar = false
+config.hide_tab_bar_if_only_one_tab = false
+
+-- タブの最大幅
+config.tab_max_width = 32
+
+-- タブバーの背景色
+config.colors = {
+  tab_bar = {
+    background = "#1a1b26",
+  },
+}
+
+-- タブの追加ボタンを非表示
+config.show_new_tab_button_in_tab_bar = false
+
+-- タブバーのスタイル
+config.window_frame = {
+  font = wezterm.font({ family = "JetBrains Mono", weight = "Bold" }),
+  font_size = 12.0,
+}
+
+----------------------------------------------------
+-- カスタムタブの見た目
+----------------------------------------------------
+-- NerdFontsのアイコン
+local SOLID_LEFT_ARROW = wezterm.nerdfonts.ple_lower_right_triangle
+local SOLID_RIGHT_ARROW = wezterm.nerdfonts.ple_upper_left_triangle
+
+wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
+  local background = "#3b4261"
+  local foreground = "#c0caf5"
+
+  if tab.is_active then
+    background = "#7aa2f7"
+    foreground = "#1a1b26"
+  elseif hover then
+    background = "#545c7e"
+    foreground = "#c0caf5"
+  end
+
+  local edge_background = "#1a1b26"
+  local edge_foreground = background
+
+  local title = tab.active_pane.title
+  -- タイトルが長すぎる場合は短縮
+  if #title > max_width - 6 then
+    title = wezterm.truncate_right(title, max_width - 6) .. "…"
+  end
+
+  return {
+    { Background = { Color = edge_background } },
+    { Foreground = { Color = edge_foreground } },
+    { Text = SOLID_LEFT_ARROW },
+    { Background = { Color = background } },
+    { Foreground = { Color = foreground } },
+    { Text = " " .. title .. " " },
+    { Background = { Color = edge_background } },
+    { Foreground = { Color = edge_foreground } },
+    { Text = SOLID_RIGHT_ARROW },
+  }
+end)
 
 return config


### PR DESCRIPTION
## 📦 Phase 2: タブバーのカスタマイズ

カスタムタブバーデザインを実装しました。

### 追加された機能
- ✅ **NerdFontsアイコン**: 三角形（◢ タイトル ◣）でモダンなデザイン
- ✅ **カラー分け**: アクティブタブは青色（#7aa2f7）、非アクティブはグレー（#3b4261）
- ✅ **ホバー効果**: マウスオーバーで色が変化
- ✅ **クリーンなUI**: 新規タブボタンを非表示
- ✅ **Tokyo Nightテーマ**: 配色を統一（背景 #1a1b26）

### スクリーンショット
複数タブを開いて確認済み

### 動作確認
- [x] 設定ファイルの構文チェック完了
- [x] タブデザインの表示確認
- [x] アクティブ/非アクティブの色分け確認
- [x] ホバー効果の確認

### 次のステップ
Phase 3でキーバインド設定（Leaderキー + モジュール分割）を予定